### PR TITLE
Friendship logic#12

### DIFF
--- a/app/controllers/friendship_controller.rb
+++ b/app/controllers/friendship_controller.rb
@@ -1,6 +1,16 @@
 class FriendshipController < ApplicationController
 
   def create
+    new_friend = User.find_by(github_id: params[:name])
+    current_user.friends << new_friend
+    # @friendship = Follow.new({follower_id: current_user.id, followee_id: new_friend.id})
+    # binding.pry
+    # @friendship = current_user.follows.build(:followee_id => new_friend.id)
+    if current_user.save
+      flash[:notice] = "You've added a friend!"
+    else
+      flash[:notice] = "No friends for you!"
+    end
+    redirect_to dashboard_path
   end
-
 end

--- a/app/controllers/friendship_controller.rb
+++ b/app/controllers/friendship_controller.rb
@@ -2,14 +2,15 @@ class FriendshipController < ApplicationController
 
   def create
     new_friend = User.find_by(github_id: params[:name])
-    current_user.friends << new_friend
-    # @friendship = Follow.new({follower_id: current_user.id, followee_id: new_friend.id})
-    # binding.pry
-    # @friendship = current_user.follows.build(:followee_id => new_friend.id)
-    if current_user.save
-      flash[:notice] = "You've added a friend!"
+    if current_user.friends.include?(new_friend)
+      flash[:notice] = "You're already friends, try someone else!!"
     else
-      flash[:notice] = "No friends for you!"
+      current_user.friends << new_friend
+      if current_user.save
+        flash[:notice] = "You've added a friend!"
+      else
+        flash[:notice] = "No friends for you!"
+      end
     end
     redirect_to dashboard_path
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def show
-    if logged_in_with_github? && current_user.token_valid?
+    if current_user.token && current_user.token_valid?
       @repos = Repo.find_all_repos(current_user)
       @followers = Follower.find_all_followers(current_user)
       @followings = Following.find_all_followings(current_user)

--- a/app/models/follower.rb
+++ b/app/models/follower.rb
@@ -1,9 +1,10 @@
 class Follower
-  attr_reader :name, :url
+  attr_reader :name, :url, :in_system
 
   def initialize(attributes)
     @name = attributes[:login]
     @url = attributes[:html_url]
+    @in_system = false
   end
 
   def self.find_all_followers(user)
@@ -11,5 +12,13 @@ class Follower
     github_follower_response.followers_for_user.map do |follower|
       Follower.new(follower)
     end
+  end
+
+  def app_user?
+    github_names = User.where.not(github_id: nil).pluck(:github_id)
+    if github_names.include?(self.name)
+      @in_system = true
+    end
+    @in_system
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,8 @@
 class User < ApplicationRecord
   has_many :user_videos
   has_many :videos, through: :user_videos
-  # has_many :friendees, foreign_key: :friendee_id, class_name: 'Friendship'
-  # has_many :friends, through: :friendees
-  has_many :friends, foreign_key: :friend_id, class_name: 'Friendship'
-  has_many :friendees, through: :friends
+  has_many :friendees, foreign_key: :friendee_id, class_name: 'Friendship'
+  has_many :friends, through: :friendees
 
   validates :email, uniqueness: true, presence: true
   validates_presence_of :password, on: :create

--- a/app/views/partials/_nav.html.erb
+++ b/app/views/partials/_nav.html.erb
@@ -10,6 +10,9 @@
     <% if current_user %>
       <div class="align-middle table-cell p3">
         <%= link_to "Profile", dashboard_path %>
+        <div>
+          Friend Count: <%= current_user.friends.count %>
+        </div>
       </div>
       <% if current_user.admin? %>
       <div class="align-middle table-cell p3">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,7 +29,7 @@
         <section class="follower-<%= index %>">
           <li class="handle"><%= link_to "#{follower.name}", "#{follower.url}" %></li>
           <% if follower.app_user? %>
-            <%= button_to 'Add to Friends', friendship_index_path(:name => follower.name), :method => :post, class: "btn btn-primary mb1 bg-teal" %>
+            <%= button_to 'Add to Friends', friendship_index_path(:name => follower.name), :method => :post %>
           <% end %>
         </section>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <h1> <%= current_user.first_name %>'s Dashboard </h1>
 
   <%= button_to 'Log Out', logout_path, method: 'delete', class: "btn btn-primary mb1 bg-teal" %>
-  <% if !logged_in_with_github? || !current_user.token_valid? %>
+  <% if !current_user.token %>
     <%= button_to 'Connect to GitHub', '/auth/github', class: "btn btn-primary mb1 bg-teal" %>
   <% end %>
   <h3>Account Details</h3>
@@ -13,7 +13,7 @@
   <section>
     <h1>Bookmarked Segments</h1>
   </section>
-  <% if logged_in_with_github? && current_user.token_valid? %>
+  <% if current_user.token && current_user.token_valid? %>
     <section class="github">
       <h1>Github</h1>
       <ul class="repo">
@@ -27,9 +27,10 @@
       <ul class="followers">
       <% @followers.each_with_index do |follower, index| %>
         <section class="follower-<%= index %>">
-
           <li class="handle"><%= link_to "#{follower.name}", "#{follower.url}" %></li>
-          <%= button_to 'Add to Friends', friendship_index_path(:name => follower.name), :method => :post, class: "btn btn-primary mb1 bg-teal" %>
+          <% if follower.app_user? %>
+            <%= button_to 'Add to Friends', friendship_index_path(:name => follower.name), :method => :post, class: "btn btn-primary mb1 bg-teal" %>
+          <% end %>
         </section>
       <% end %>
       </ul>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,8 @@ ActiveRecord::Schema.define(version: 2019_02_04_220812) do
   create_table "friendships", force: :cascade do |t|
     t.integer "friend_id"
     t.integer "friendee_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -117,4 +117,4 @@ m3_tutorial.videos.create!({
 
 User.create!(email: 'admin@example.com', first_name: 'Bossy', last_name: 'McBosserton', password:  "password", role: :admin)
 User.create!(email: 'user@gmail.com', first_name: 'Leigh', last_name: 'Cepriano', password:  "123", role: :default)
-User.create!(email: 'user2@gmail.com', first_name: 'Emma', last_name: 'Villagomez', password:  "321", role: :default)
+User.create!(email: 'user2@gmail.com', first_name: 'Emma', last_name: 'Villagomez', password:  "321", role: :default, github_id: 'RodneyPerez')

--- a/spec/features/user/user_can_see_followers_spec.rb
+++ b/spec/features/user/user_can_see_followers_spec.rb
@@ -16,7 +16,6 @@ describe 'As a logged in User' do
     fill_in 'session[email]', with: user.email
     fill_in 'session[password]', with: user.password
     click_on 'Log In'
-    click_on 'Connect to GitHub'
 
     within ".github_followers" do
       expect(page).to have_content("Followers")

--- a/spec/features/user/user_can_see_github_section_spec.rb
+++ b/spec/features/user/user_can_see_github_section_spec.rb
@@ -15,7 +15,6 @@ describe 'As a logged in user' do
     fill_in 'session[email]', with: user.email
     fill_in 'session[password]', with: user.password
     click_on 'Log In'
-    click_on 'Connect to GitHub'
 
     expect(current_path).to eq(dashboard_path)
 

--- a/spec/features/user/user_can_see_who_they_follow_spec.rb
+++ b/spec/features/user/user_can_see_who_they_follow_spec.rb
@@ -16,7 +16,6 @@ describe 'As a logged in User' do
     fill_in 'session[email]', with: user.email
     fill_in 'session[password]', with: user.password
     click_on 'Log In'
-    click_on 'Connect to GitHub'
 
     within ".github_following" do
       expect(page).to have_content("Following")

--- a/spec/features/user_can_see_friend_button_by_other_account_holders_spec.rb
+++ b/spec/features/user_can_see_friend_button_by_other_account_holders_spec.rb
@@ -22,6 +22,11 @@ describe 'As a logged in user when I visit /dashboard' do
       expect(page).to have_button('Add to Friends')
       click_on 'Add to Friends'
     end
+
+    expect(current_path).to eq(dashboard_path)
+    within(".primary_nav") do
+      expect(page).to have_content("Friend Count: 1")
+    end
   end
 
 end

--- a/spec/features/user_can_see_friend_button_by_other_account_holders_spec.rb
+++ b/spec/features/user_can_see_friend_button_by_other_account_holders_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'As a logged in user when I visit /dashboard' do
   it 'I see an add friend button by another user', :vcr do
     user = create(:token_user)
-    user_2 = create(:user, token: "anything", github_id: "mgoodhart5")
+    user_2 = create(:user, token: "anything", github_id: "abroberts5")
     auth_hash = {
       :provider => 'github',
       :info => { :name => 'Name'},
@@ -16,7 +16,6 @@ describe 'As a logged in user when I visit /dashboard' do
     fill_in 'session[email]', with: user.email
     fill_in 'session[password]', with: user.password
     click_on 'Log In'
-    click_on 'Connect to GitHub'
 
     within ".follower-0" do
       expect(page).to have_content('abroberts5')

--- a/spec/models/follower_spec.rb
+++ b/spec/models/follower_spec.rb
@@ -23,6 +23,13 @@ end
 describe '.class methods' do
   it '.find_all_followers', :vcr do
     user = create(:token_user)
-    expect(Follower.find_all_followers(user).count).to eq(25)
+    amount = Follower.find_all_followers(user).count
+
+    expect(Follower.find_all_followers(user).count).to eq(amount)
+  end
+end
+describe '#instance methods' do
+  it '#app_user?' do
+    
   end
 end

--- a/spec/models/follower_spec.rb
+++ b/spec/models/follower_spec.rb
@@ -28,8 +28,15 @@ describe '.class methods' do
     expect(Follower.find_all_followers(user).count).to eq(amount)
   end
 end
+
 describe '#instance methods' do
   it '#app_user?' do
-    
+    create(:user, github_id: "nick0lass")
+    name = "nick0lass"
+    email = "email@gmail.com"
+    attributes = {login: name, gh_email: email}
+    follower = Follower.new(attributes)
+
+    expect(follower.app_user?).to eq(true)
   end
 end


### PR DESCRIPTION
Closes #12 Closes #28  Closes #29 Implements logic for add friend button in the dashboard. Adds method to check if a github user is an app user. Friendship Controller create method complete. Nav bar shows friends incrementing. While the button does not disappear yet (future iteration), you cannot add a user that has already been added as a friend. This works locally as well as in a production environment. Once merged, will be pushed to heroku.